### PR TITLE
docs: fix bad link to the content delivery 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This sdk is designed to help build client side and server side content managed a
 
 ## Features
 
-- Fetch content and slots using the [Content Delivery 1](https://docs.amplience.net/integration/deliveryapi.html#the-content-delivery-api) and/or [Content Delivery 2](https://docs.amplience.net/development/contentdelivery/readme.htm)
+- Fetch content and slots using the [Content Delivery 1](https://docs.amplience.net/integration/deliveryapi.html#the-content-delivery-api) and/or [Content Delivery 2](https://docs.amplience.net/development/contentdelivery/readme.html)
 - Fetch preview content using Virtual Staging
 - Transform content using the [Content Rendering Service](https://docs.amplience.net/integration/contentrenderingservice.html#the-content-rendering-service)
 - Localize content


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [X] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

- Incorrect Content Delivery 2 link


## What is the new behavior?

- Fixed Content Delivery 2 link

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Fixes issue #18 