### PR TITLE
feat(content meta): include hierarchy _meta for content items

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "clean": "trash build test dist",
     "all": "run-s clean test cov:check doc:html",
-    "release": "run-s all standard-version doc:publish"
+    "release": "run-s all standard-version doc:publish",
+    "prepack": "npm ci && npm run build"
   },
   "scripts-info": {
     "info": "Display information about the package scripts",

--- a/src/lib/content/model/ContentMeta.spec.ts
+++ b/src/lib/content/model/ContentMeta.spec.ts
@@ -18,6 +18,10 @@ describe('ContentMeta', () => {
         lifecycle: {
           expiryTime: '2018-07-06T22:59:59.999Z',
         },
+        hierarchy: {
+          parentId: 'e72ec600-2975-4c6a-80dd-3f55981cd254',
+          root: false,
+        },
       });
 
       expect(meta.schema).to.eq(
@@ -30,6 +34,7 @@ describe('ContentMeta', () => {
       expect(meta.edition.start).to.eq('2018-06-30T23:00:00.000Z');
       expect(meta.edition.end).to.eq('2018-07-06T22:59:59.999Z');
       expect(meta.lifecycle.expiryTime).to.eq('2018-07-06T22:59:59.999Z');
+      expect(meta.hierarchy.root).to.eq(false);
     });
 
     it('should serialize to json', () => {
@@ -47,6 +52,10 @@ describe('ContentMeta', () => {
         lifecycle: {
           expiryTime: '2018-07-06T22:59:59.999Z',
         },
+        hierarchy: {
+          parentId: 'e72ec600-2975-4c6a-80dd-3f55981cd254',
+          root: false,
+        },
       });
 
       expect(meta.toJSON()).to.deep.eq({
@@ -62,6 +71,10 @@ describe('ContentMeta', () => {
         },
         lifecycle: {
           expiryTime: '2018-07-06T22:59:59.999Z',
+        },
+        hierarchy: {
+          parentId: 'e72ec600-2975-4c6a-80dd-3f55981cd254',
+          root: false,
         },
       });
     });

--- a/src/lib/content/model/ContentMeta.ts
+++ b/src/lib/content/model/ContentMeta.ts
@@ -1,6 +1,7 @@
 import { Edition } from './Edition';
 import { ContentLifecycle } from './ContentLifecycle';
 import { FragmentMeta } from './FragmentMeta';
+import { Hierarchy } from './Hierarchy';
 
 /**
  * Class providing meta data about an Content Reference resource.
@@ -44,6 +45,11 @@ export class ContentMeta extends FragmentMeta {
   name: string;
 
   /**
+   * Metadata related to hierarchies
+   */
+  hierarchy?: Hierarchy;
+
+  /**
    * Creates a new ContentMeta instance.
    * @param data JSON representation of the ContentMeta model
    */
@@ -85,6 +91,10 @@ export class ContentMeta extends FragmentMeta {
 
     if (this.lifecycle) {
       result.lifecycle = this.lifecycle.toJSON();
+    }
+
+    if (this.hierarchy) {
+      result.hierarchy = this.hierarchy;
     }
 
     return result;

--- a/src/lib/content/model/Hierarchy.ts
+++ b/src/lib/content/model/Hierarchy.ts
@@ -1,0 +1,13 @@
+/**
+ * Hierarchy status of a ContentItem.
+ */
+export interface Hierarchy {
+  /**
+   * Determines Hierarchy is the root item
+   */
+  root: boolean;
+  /**
+   * Parent ID of a Hierarcy
+   */
+  parentId?: string;
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When requesting content items hierarchy _meta was not included in the SDK response


## What is the new behavior?
Requesting content items now returns hierarchy _meta.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


