### PR TITLE
fix(json walker): updated to check that value is not null as null is an object

### DIFF
--- a/src/lib/utils/JsonWalker.spec.ts
+++ b/src/lib/utils/JsonWalker.spec.ts
@@ -23,6 +23,27 @@ describe('walkAndReplace', () => {
     expect(after).to.deep.eq(['0', '1', '2', '']);
   });
 
+  it('should handle falsy values in arrays', () => {
+    const data = [false, null, undefined];
+
+    const before = [];
+    const after = [];
+    const result = walkAndReplace(data, {
+      beforeWalk: (value: any, pointer: string[]) => {
+        before.push(pointer.join('-'));
+        return value;
+      },
+      afterWalk: (value: any, pointer: string[]) => {
+        after.push(pointer.join('-'));
+        return value;
+      },
+    });
+
+    expect(result).to.deep.eq(data);
+    expect(before).to.deep.eq(['', '0', '1', '2']);
+    expect(after).to.deep.eq(['0', '1', '2', '']);
+  });
+
   it('should visit nested array children', () => {
     const data = [['a', 'b', 'c']];
 
@@ -56,6 +77,27 @@ describe('walkAndReplace', () => {
       },
       afterWalk: (value: any, pointer: string[]) => {
         after.push(pointer.join('/'));
+        return value;
+      },
+    });
+
+    expect(result).to.deep.eq(data);
+    expect(before).to.deep.eq(['', 'a', 'b', 'c']);
+    expect(after).to.deep.eq(['a', 'b', 'c', '']);
+  });
+
+  it('should handle falsy values in arrays', () => {
+    const data = { a: false, b: null, c: undefined };
+
+    const before = [];
+    const after = [];
+    const result = walkAndReplace(data, {
+      beforeWalk: (value: any, pointer: string[]) => {
+        before.push(pointer.join('-'));
+        return value;
+      },
+      afterWalk: (value: any, pointer: string[]) => {
+        after.push(pointer.join('-'));
         return value;
       },
     });

--- a/src/lib/utils/JsonWalker.ts
+++ b/src/lib/utils/JsonWalker.ts
@@ -26,7 +26,7 @@ export function walkAndReplace(
       newValue.push(entryValue);
     }
     value = newValue;
-  } else if (typeof value === 'object') {
+  } else if (typeof value === 'object' && value !== null) {
     const newValue = {};
     const keys = Object.keys(value);
     for (const entryKey of keys) {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently the JSON walker functionality will take a null value and deal with it like an object as the typeof information on a null value is "object".


## What is the new behavior?
The walker will now check that the value is null and treat it accordingly.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Currently we are throwing an exception if the value is null, but this will now be returned and if that is not expected it will cause errors with the library implementation.