### PR TITLE
feat(env): updating i1, c1, default, and virtual-staging urls

### DIFF
--- a/src/lib/ContentClient.spec.ts
+++ b/src/lib/ContentClient.spec.ts
@@ -44,7 +44,7 @@ describe('ContentClient', () => {
         const mocks = new MockAdapter(null);
         mocks
           .onGet(
-            'https://c1.adis.ws/cms/content/query?query=%7B%22sys.iri%22%3A%22http%3A%2F%2Fcontent.cms.amplience.com%2F2c7efa09-7e31-4503-8d00-5a150ff82f17%22%7D&fullBodyObject=true&scope=tree&store=test'
+            'https://cdn.c1.amplience.net/cms/content/query?query=%7B%22sys.iri%22%3A%22http%3A%2F%2Fcontent.cms.amplience.com%2F2c7efa09-7e31-4503-8d00-5a150ff82f17%22%7D&fullBodyObject=true&scope=tree&store=test'
           )
           .reply(200, V1_SINGLE_RESULT);
 
@@ -96,7 +96,7 @@ describe('ContentClient', () => {
         const mocks = new MockAdapter(null);
         mocks
           .onGet(
-            'https://c1.adis.ws/cms/content/query?query=%7B%22sys.iri%22%3A%22http%3A%2F%2Fcontent.cms.amplience.com%2F2c7efa09-7e31-4503-8d00-5a150ff82f17%22%7D&fullBodyObject=true&scope=tree&store=test'
+            'https://cdn.c1.amplience.net/cms/content/query?query=%7B%22sys.iri%22%3A%22http%3A%2F%2Fcontent.cms.amplience.com%2F2c7efa09-7e31-4503-8d00-5a150ff82f17%22%7D&fullBodyObject=true&scope=tree&store=test'
           )
           .reply(200, V1_SINGLE_RESULT);
 

--- a/src/lib/content/coordinators/GetContentItemV1Impl.spec.ts
+++ b/src/lib/content/coordinators/GetContentItemV1Impl.spec.ts
@@ -107,7 +107,7 @@ describe('GetContentItemV1Impl', () => {
             schema:
               'http://bigcontent.io/cms/schema/v1/core#/definitions/image-link',
           },
-          defaultHost: 'i1.adis.ws',
+          defaultHost: 'classic.cdn.media.amplience.net',
           endpoint: 'dcdemo',
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           mediaType: 'image',
@@ -132,7 +132,7 @@ describe('GetContentItemV1Impl', () => {
             schema:
               'http://bigcontent.io/cms/schema/v1/core#/definitions/image-link',
           },
-          defaultHost: 'i1.adis.ws',
+          defaultHost: 'classic.cdn.media.amplience.net',
           endpoint: 'dcdemo',
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           mediaType: 'image',
@@ -167,7 +167,7 @@ describe('GetContentItemV1Impl', () => {
               id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
               name: 'shutterstock_749703970',
               endpoint: 'dcdemo',
-              defaultHost: 'i1.adis.ws',
+              defaultHost: 'classic.cdn.media.amplience.net',
               mediaType: 'image',
             },
             content: {

--- a/src/lib/content/coordinators/GetContentItemV1Impl.spec.ts
+++ b/src/lib/content/coordinators/GetContentItemV1Impl.spec.ts
@@ -107,7 +107,7 @@ describe('GetContentItemV1Impl', () => {
             schema:
               'http://bigcontent.io/cms/schema/v1/core#/definitions/image-link',
           },
-          defaultHost: 'classic.cdn.media.amplience.net',
+          defaultHost: 'cdn.media.amplience.net',
           endpoint: 'dcdemo',
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           mediaType: 'image',
@@ -132,7 +132,7 @@ describe('GetContentItemV1Impl', () => {
             schema:
               'http://bigcontent.io/cms/schema/v1/core#/definitions/image-link',
           },
-          defaultHost: 'classic.cdn.media.amplience.net',
+          defaultHost: 'cdn.media.amplience.net',
           endpoint: 'dcdemo',
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           mediaType: 'image',
@@ -167,7 +167,7 @@ describe('GetContentItemV1Impl', () => {
               id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
               name: 'shutterstock_749703970',
               endpoint: 'dcdemo',
-              defaultHost: 'classic.cdn.media.amplience.net',
+              defaultHost: 'cdn.media.amplience.net',
               mediaType: 'image',
             },
             content: {

--- a/src/lib/content/coordinators/GetContentItemV1Impl.ts
+++ b/src/lib/content/coordinators/GetContentItemV1Impl.ts
@@ -33,7 +33,10 @@ export class GetContentItemV1Impl implements GetContentItemById {
     private readonly config: ContentClientConfigV1,
     private readonly mapper: ContentMapper
   ) {
-    this.contentClient = createContentClient(this.config, 'https://c1.adis.ws');
+    this.contentClient = createContentClient(
+      this.config,
+      'https://cdn.c1.amplience.net'
+    );
   }
 
   /**

--- a/src/lib/content/coordinators/__fixtures__/v1/NESTED_CONTENT.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/NESTED_CONTENT.json
@@ -55,7 +55,7 @@
       "id": "ddf4eac9-7822-401c-97d6-b1be985e421c",
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "i1.adis.ws",
+      "defaultHost": "classic.cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     },

--- a/src/lib/content/coordinators/__fixtures__/v1/NESTED_CONTENT.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/NESTED_CONTENT.json
@@ -55,7 +55,7 @@
       "id": "ddf4eac9-7822-401c-97d6-b1be985e421c",
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "classic.cdn.media.amplience.net",
+      "defaultHost": "cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     },

--- a/src/lib/content/coordinators/__fixtures__/v1/SINGLE_LEGACY_RESULT_WITH_IMAGE.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/SINGLE_LEGACY_RESULT_WITH_IMAGE.json
@@ -20,7 +20,7 @@
     {
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "classic.cdn.media.amplience.net",
+      "defaultHost": "cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     }

--- a/src/lib/content/coordinators/__fixtures__/v1/SINGLE_LEGACY_RESULT_WITH_IMAGE.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/SINGLE_LEGACY_RESULT_WITH_IMAGE.json
@@ -20,7 +20,7 @@
     {
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "i1.adis.ws",
+      "defaultHost": "classic.cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     }

--- a/src/lib/content/coordinators/__fixtures__/v1/SINGLE_RESULT_WITH_IMAGE.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/SINGLE_RESULT_WITH_IMAGE.json
@@ -24,7 +24,7 @@
       "id": "ddf4eac9-7822-401c-97d6-b1be985e421c",
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "classic.cdn.media.amplience.net",
+      "defaultHost": "cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     }

--- a/src/lib/content/coordinators/__fixtures__/v1/SINGLE_RESULT_WITH_IMAGE.json
+++ b/src/lib/content/coordinators/__fixtures__/v1/SINGLE_RESULT_WITH_IMAGE.json
@@ -24,7 +24,7 @@
       "id": "ddf4eac9-7822-401c-97d6-b1be985e421c",
       "name": "shutterstock_749703970",
       "endpoint": "dcdemo",
-      "defaultHost": "i1.adis.ws",
+      "defaultHost": "classic.cdn.media.amplience.net",
       "@id": "http://image.cms.amplience.com/ddf4eac9-7822-401c-97d6-b1be985e421c",
       "mediaType": "image"
     }

--- a/src/lib/content/coordinators/__fixtures__/v2/RESULT.json
+++ b/src/lib/content/coordinators/__fixtures__/v2/RESULT.json
@@ -26,7 +26,7 @@
             "id": "88e5826a-7c69-415f-8c32-bc53445d85e8",
             "name": "np",
             "endpoint": "ampproduct",
-            "defaultHost": "i1.adis.ws"
+            "defaultHost": "classic.cdn.media.amplience.net"
           },
           "altText": "Nick Piper"
         },
@@ -46,7 +46,7 @@
         "id": "099378a3-418f-48bd-ba91-f1ceeb55b2fc",
         "name": "IMG_3598",
         "endpoint": "ampproduct",
-        "defaultHost": "i1.adis.ws"
+        "defaultHost": "classic.cdn.media.amplience.net"
       },
       "altText": "Built in the North!"
     },

--- a/src/lib/content/coordinators/__fixtures__/v2/RESULT.json
+++ b/src/lib/content/coordinators/__fixtures__/v2/RESULT.json
@@ -26,7 +26,7 @@
             "id": "88e5826a-7c69-415f-8c32-bc53445d85e8",
             "name": "np",
             "endpoint": "ampproduct",
-            "defaultHost": "classic.cdn.media.amplience.net"
+            "defaultHost": "cdn.media.amplience.net"
           },
           "altText": "Nick Piper"
         },
@@ -46,7 +46,7 @@
         "id": "099378a3-418f-48bd-ba91-f1ceeb55b2fc",
         "name": "IMG_3598",
         "endpoint": "ampproduct",
-        "defaultHost": "classic.cdn.media.amplience.net"
+        "defaultHost": "cdn.media.amplience.net"
       },
       "altText": "Built in the North!"
     },

--- a/src/lib/content/mapper/ContentMapper.spec.ts
+++ b/src/lib/content/mapper/ContentMapper.spec.ts
@@ -189,7 +189,7 @@ describe('ContentMapper', () => {
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'i1.adis.ws',
+          defaultHost: 'classic.cdn.media.amplience.net',
         },
       });
       expect(result.image).to.be.instanceOf(Image);
@@ -207,7 +207,7 @@ describe('ContentMapper', () => {
             id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
             name: 'image',
             endpoint: 'test',
-            defaultHost: 'i1.adis.ws',
+            defaultHost: 'classic.cdn.media.amplience.net',
           },
         });
         expect(result.image).to.be.instanceOf(Video);

--- a/src/lib/content/mapper/ContentMapper.spec.ts
+++ b/src/lib/content/mapper/ContentMapper.spec.ts
@@ -189,7 +189,7 @@ describe('ContentMapper', () => {
           id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'classic.cdn.media.amplience.net',
+          defaultHost: 'cdn.media.amplience.net',
         },
       });
       expect(result.image).to.be.instanceOf(Image);
@@ -207,7 +207,7 @@ describe('ContentMapper', () => {
             id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
             name: 'image',
             endpoint: 'test',
-            defaultHost: 'classic.cdn.media.amplience.net',
+            defaultHost: 'cdn.media.amplience.net',
           },
         });
         expect(result.image).to.be.instanceOf(Video);

--- a/src/lib/media/Image.spec.ts
+++ b/src/lib/media/Image.spec.ts
@@ -15,7 +15,7 @@ describe('Image', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const content = new Image(json, config);
@@ -33,12 +33,12 @@ describe('Image', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const content = new Image(json, config);
       const url = content.url().build();
-      expect(url).to.eq('https://classic.cdn.media.amplience.net/i/test/image');
+      expect(url).to.eq('https://cdn.media.amplience.net/i/test/image');
     });
   });
 });

--- a/src/lib/media/Image.spec.ts
+++ b/src/lib/media/Image.spec.ts
@@ -15,7 +15,7 @@ describe('Image', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const content = new Image(json, config);
@@ -33,12 +33,12 @@ describe('Image', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const content = new Image(json, config);
       const url = content.url().build();
-      expect(url).to.eq('https://i1.adis.ws/i/test/image');
+      expect(url).to.eq('https://classic.cdn.media.amplience.net/i/test/image');
     });
   });
 });

--- a/src/lib/media/ImageUrlBuilder.spec.ts
+++ b/src/lib/media/ImageUrlBuilder.spec.ts
@@ -13,13 +13,15 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test/image'
+      );
     });
 
     it('should support http protocol', () => {
@@ -27,14 +29,16 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       builder.protocol('http');
-      expect(builder.build()).to.eq('http://default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq(
+        'http://cdn.media.amplience.net/i/test/image'
+      );
     });
 
     it('should support protocol relative protocol', () => {
@@ -42,14 +46,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       builder.protocol('//');
-      expect(builder.build()).to.eq('//default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq('//cdn.media.amplience.net/i/test/image');
     });
   });
 
@@ -59,34 +63,38 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test/image'
+      );
     });
     it('should use defaultHost by default for insecure URLs', () => {
       const image = new Image(
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       builder.protocol('http');
-      expect(builder.build()).to.eq('http://default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq(
+        'http://cdn.media.amplience.net/i/test/image'
+      );
     });
     it('should use override host if set', () => {
       const image = new Image(
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
@@ -100,7 +108,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -120,7 +128,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -141,7 +149,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -164,7 +172,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -182,7 +190,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -193,14 +201,16 @@ describe('ImageUrlBuilder', () => {
       const builder = new ImageUrlBuilder(image);
 
       builder.protocol('https');
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test/image');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test/image'
+      );
     });
     it('should use secureMediaHost for https urls', () => {
       const image = new Image(
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -221,7 +231,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         {
           ...config,
@@ -242,13 +252,15 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test ',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test%20/image');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test%20/image'
+      );
     });
   });
 
@@ -258,12 +270,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image ',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test/image%20');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test/image%20'
+      );
     });
   });
 
@@ -273,14 +287,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.format(ImageFormat.WEBP);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image.webp'
+        'https://cdn.media.amplience.net/i/test/image.webp'
       );
     });
   });
@@ -291,13 +305,15 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.seoFileName('seo');
-      expect(builder.build()).to.eq('https://default.adis.ws/i/test/image/seo');
+      expect(builder.build()).to.eq(
+        'https://cdn.media.amplience.net/i/test/image/seo'
+      );
     });
 
     it('should encode seoFileName', () => {
@@ -305,14 +321,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.seoFileName('seo ');
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image/seo%20'
+        'https://cdn.media.amplience.net/i/test/image/seo%20'
       );
     });
 
@@ -321,7 +337,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
@@ -329,7 +345,7 @@ describe('ImageUrlBuilder', () => {
       builder.seoFileName('seo');
       builder.format(ImageFormat.JPEG);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image/seo.jpg'
+        'https://cdn.media.amplience.net/i/test/image/seo.jpg'
       );
     });
   });
@@ -340,14 +356,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.template('thumb');
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?$thumb$'
+        'https://cdn.media.amplience.net/i/test/image?$thumb$'
       );
     });
 
@@ -356,14 +372,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.template('thumb ');
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?$thumb%20$'
+        'https://cdn.media.amplience.net/i/test/image?$thumb%20$'
       );
     });
 
@@ -372,7 +388,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
@@ -381,7 +397,7 @@ describe('ImageUrlBuilder', () => {
       builder.template('poi');
 
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?$thumb$&$poi$'
+        'https://cdn.media.amplience.net/i/test/image?$thumb$&$poi$'
       );
     });
   });
@@ -392,14 +408,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.parameter('offers', '241');
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?offers=241'
+        'https://cdn.media.amplience.net/i/test/image?offers=241'
       );
     });
 
@@ -408,14 +424,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.parameter('offers ', '241 ');
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?offers%20=241%20'
+        'https://cdn.media.amplience.net/i/test/image?offers%20=241%20'
       );
     });
   });
@@ -426,14 +442,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.quality(70);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?qlt=70'
+        'https://cdn.media.amplience.net/i/test/image?qlt=70'
       );
     });
   });
@@ -444,14 +460,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.sharpen(0, 1, 1, 0.05);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?unsharp=0,1,1,0.05'
+        'https://cdn.media.amplience.net/i/test/image?unsharp=0,1,1,0.05'
       );
     });
   });
@@ -462,14 +478,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.width(100);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?w=100'
+        'https://cdn.media.amplience.net/i/test/image?w=100'
       );
     });
   });
@@ -480,14 +496,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'default.adis.ws',
+          defaultHost: 'cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.height(100);
       expect(builder.build()).to.eq(
-        'https://default.adis.ws/i/test/image?h=100'
+        'https://cdn.media.amplience.net/i/test/image?h=100'
       );
     });
   });

--- a/src/lib/media/ImageUrlBuilder.spec.ts
+++ b/src/lib/media/ImageUrlBuilder.spec.ts
@@ -13,14 +13,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image'
+        'https://default.cdn.media.amplience.net/i/test/image'
       );
     });
 
@@ -29,7 +29,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
@@ -37,7 +37,7 @@ describe('ImageUrlBuilder', () => {
       const builder = new ImageUrlBuilder(image);
       builder.protocol('http');
       expect(builder.build()).to.eq(
-        'http://cdn.media.amplience.net/i/test/image'
+        'http://default.cdn.media.amplience.net/i/test/image'
       );
     });
 
@@ -46,14 +46,16 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       builder.protocol('//');
-      expect(builder.build()).to.eq('//cdn.media.amplience.net/i/test/image');
+      expect(builder.build()).to.eq(
+        '//default.cdn.media.amplience.net/i/test/image'
+      );
     });
   });
 
@@ -63,14 +65,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image'
+        'https://default.cdn.media.amplience.net/i/test/image'
       );
     });
     it('should use defaultHost by default for insecure URLs', () => {
@@ -78,7 +80,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
@@ -86,7 +88,7 @@ describe('ImageUrlBuilder', () => {
       const builder = new ImageUrlBuilder(image);
       builder.protocol('http');
       expect(builder.build()).to.eq(
-        'http://cdn.media.amplience.net/i/test/image'
+        'http://default.cdn.media.amplience.net/i/test/image'
       );
     });
     it('should use override host if set', () => {
@@ -94,7 +96,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
@@ -108,7 +110,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -128,7 +130,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -149,14 +151,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
           stagingEnvironment:
             'fhboh562c3tx1844c2ycknz96-gvzrfgnzc-1546264721816.staging.bigcontent.io',
-          mediaHost: 'invalid.adis.ws',
-          secureMediaHost: 'invalid.adis.ws',
+          mediaHost: 'invalid.cdn.media.amplience.net',
+          secureMediaHost: 'invalid.cdn.media.amplience.net',
         }
       );
 
@@ -172,7 +174,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -190,7 +192,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -202,7 +204,7 @@ describe('ImageUrlBuilder', () => {
 
       builder.protocol('https');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image'
+        'https://default.cdn.media.amplience.net/i/test/image'
       );
     });
     it('should use secureMediaHost for https urls', () => {
@@ -210,7 +212,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -231,7 +233,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         {
           ...config,
@@ -252,14 +254,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test ',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
 
       const builder = new ImageUrlBuilder(image);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test%20/image'
+        'https://default.cdn.media.amplience.net/i/test%20/image'
       );
     });
   });
@@ -270,13 +272,13 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image ',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image%20'
+        'https://default.cdn.media.amplience.net/i/test/image%20'
       );
     });
   });
@@ -287,14 +289,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.format(ImageFormat.WEBP);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image.webp'
+        'https://default.cdn.media.amplience.net/i/test/image.webp'
       );
     });
   });
@@ -305,14 +307,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.seoFileName('seo');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image/seo'
+        'https://default.cdn.media.amplience.net/i/test/image/seo'
       );
     });
 
@@ -321,14 +323,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.seoFileName('seo ');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image/seo%20'
+        'https://default.cdn.media.amplience.net/i/test/image/seo%20'
       );
     });
 
@@ -337,7 +339,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
@@ -345,7 +347,7 @@ describe('ImageUrlBuilder', () => {
       builder.seoFileName('seo');
       builder.format(ImageFormat.JPEG);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image/seo.jpg'
+        'https://default.cdn.media.amplience.net/i/test/image/seo.jpg'
       );
     });
   });
@@ -356,14 +358,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.template('thumb');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?$thumb$'
+        'https://default.cdn.media.amplience.net/i/test/image?$thumb$'
       );
     });
 
@@ -372,14 +374,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.template('thumb ');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?$thumb%20$'
+        'https://default.cdn.media.amplience.net/i/test/image?$thumb%20$'
       );
     });
 
@@ -388,7 +390,7 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
@@ -397,7 +399,7 @@ describe('ImageUrlBuilder', () => {
       builder.template('poi');
 
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?$thumb$&$poi$'
+        'https://default.cdn.media.amplience.net/i/test/image?$thumb$&$poi$'
       );
     });
   });
@@ -408,14 +410,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.parameter('offers', '241');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?offers=241'
+        'https://default.cdn.media.amplience.net/i/test/image?offers=241'
       );
     });
 
@@ -424,14 +426,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.parameter('offers ', '241 ');
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?offers%20=241%20'
+        'https://default.cdn.media.amplience.net/i/test/image?offers%20=241%20'
       );
     });
   });
@@ -442,14 +444,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.quality(70);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?qlt=70'
+        'https://default.cdn.media.amplience.net/i/test/image?qlt=70'
       );
     });
   });
@@ -460,14 +462,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.sharpen(0, 1, 1, 0.05);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?unsharp=0,1,1,0.05'
+        'https://default.cdn.media.amplience.net/i/test/image?unsharp=0,1,1,0.05'
       );
     });
   });
@@ -478,14 +480,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.width(100);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?w=100'
+        'https://default.cdn.media.amplience.net/i/test/image?w=100'
       );
     });
   });
@@ -496,14 +498,14 @@ describe('ImageUrlBuilder', () => {
         {
           name: 'image',
           endpoint: 'test',
-          defaultHost: 'cdn.media.amplience.net',
+          defaultHost: 'default.cdn.media.amplience.net',
         },
         config
       );
       const builder = new ImageUrlBuilder(image);
       builder.height(100);
       expect(builder.build()).to.eq(
-        'https://cdn.media.amplience.net/i/test/image?h=100'
+        'https://default.cdn.media.amplience.net/i/test/image?h=100'
       );
     });
   });

--- a/src/lib/media/Media.spec.ts
+++ b/src/lib/media/Media.spec.ts
@@ -21,11 +21,11 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, config);
-      expect(media.getHost(false)).to.eq('classic.cdn.media.amplience.net');
+      expect(media.getHost(false)).to.eq('cdn.media.amplience.net');
     });
 
     it('should return the stagingEnvironment host if specified', () => {
@@ -37,14 +37,14 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
         ...config,
-        stagingEnvironment: 'staging.adis.ws',
+        stagingEnvironment: 'staging.bigcontent.io',
       });
-      expect(media.getHost(false)).to.eq('staging.adis.ws');
+      expect(media.getHost(false)).to.eq('staging.bigcontent.io');
     });
 
     it('should return secureMediaHost if specified', () => {
@@ -56,14 +56,14 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
         ...config,
-        secureMediaHost: 'secure.adis.ws',
+        secureMediaHost: 'secure.cdn.media.amplience.net',
       });
-      expect(media.getHost(true)).to.eq('secure.adis.ws');
+      expect(media.getHost(true)).to.eq('secure.cdn.media.amplience.net');
     });
 
     it('should return defaultHost if secure is specified but no secureMediaHost is provided', () => {
@@ -75,11 +75,11 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, config);
-      expect(media.getHost(true)).to.eq('classic.cdn.media.amplience.net');
+      expect(media.getHost(true)).to.eq('cdn.media.amplience.net');
     });
 
     it('should return mediaHost if specified and secure is false', () => {
@@ -91,7 +91,7 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
@@ -110,14 +110,14 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
         ...config,
-        secureMediaHost: 'secure.adis.ws',
+        secureMediaHost: 'secure.cdn.media.amplience.net',
       });
-      expect(media.getHost(false)).to.eq('secure.adis.ws');
+      expect(media.getHost(false)).to.eq('secure.cdn.media.amplience.net');
     });
   });
 });

--- a/src/lib/media/Media.spec.ts
+++ b/src/lib/media/Media.spec.ts
@@ -21,11 +21,11 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, config);
-      expect(media.getHost(false)).to.eq('i1.adis.ws');
+      expect(media.getHost(false)).to.eq('classic.cdn.media.amplience.net');
     });
 
     it('should return the stagingEnvironment host if specified', () => {
@@ -37,7 +37,7 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
@@ -56,7 +56,7 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
@@ -75,11 +75,11 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, config);
-      expect(media.getHost(true)).to.eq('i1.adis.ws');
+      expect(media.getHost(true)).to.eq('classic.cdn.media.amplience.net');
     });
 
     it('should return mediaHost if specified and secure is false', () => {
@@ -91,7 +91,7 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {
@@ -110,7 +110,7 @@ describe('Media', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const media = new MediaImpl(json, {

--- a/src/lib/media/Video.spec.ts
+++ b/src/lib/media/Video.spec.ts
@@ -14,7 +14,7 @@ describe('Video', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'video',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const content = new Video(json, config);
@@ -32,12 +32,12 @@ describe('Video', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'i1.adis.ws',
+        defaultHost: 'classic.cdn.media.amplience.net',
       };
 
       const content = new Video(json, config);
       const url = content.thumbnail().build();
-      expect(url).to.eq('https://i1.adis.ws/v/test/image');
+      expect(url).to.eq('https://classic.cdn.media.amplience.net/v/test/image');
     });
   });
 });

--- a/src/lib/media/Video.spec.ts
+++ b/src/lib/media/Video.spec.ts
@@ -14,7 +14,7 @@ describe('Video', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'video',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const content = new Video(json, config);
@@ -32,12 +32,12 @@ describe('Video', () => {
         id: 'ddf4eac9-7822-401c-97d6-b1be985e421c',
         name: 'image',
         endpoint: 'test',
-        defaultHost: 'classic.cdn.media.amplience.net',
+        defaultHost: 'cdn.media.amplience.net',
       };
 
       const content = new Video(json, config);
       const url = content.thumbnail().build();
-      expect(url).to.eq('https://classic.cdn.media.amplience.net/v/test/image');
+      expect(url).to.eq('https://cdn.media.amplience.net/v/test/image');
     });
   });
 });

--- a/src/lib/rendering/coordinators/RenderContentItem.ts
+++ b/src/lib/rendering/coordinators/RenderContentItem.ts
@@ -13,7 +13,10 @@ export class RenderContentItem {
   private readonly contentClient: AxiosInstance;
 
   constructor(private readonly config: ContentClientConfigV1) {
-    this.contentClient = createContentClient(this.config, 'https://c1.adis.ws');
+    this.contentClient = createContentClient(
+      this.config,
+      'https://cdn.c1.amplience.net'
+    );
   }
 
   renderContentItem(

--- a/src/lib/staging-environment/StagingEnvironmentFactory.ts
+++ b/src/lib/staging-environment/StagingEnvironmentFactory.ts
@@ -7,7 +7,7 @@ import { GenerateDomainOptions } from './GenerateDomainOptions';
  * Default StagingEnvironmentFactoryConfig values
  */
 const DefaultStagingEnvironmentFactoryConfig: StagingEnvironmentFactoryConfig = {
-  baseUrl: 'https://virtual-staging.adis.ws',
+  baseUrl: 'https://virtual-staging.amplience.net',
 };
 
 /**

--- a/src/lib/staging-environment/StagingEnvironmentFactoryConfig.ts
+++ b/src/lib/staging-environment/StagingEnvironmentFactoryConfig.ts
@@ -11,7 +11,7 @@ export interface StagingEnvironmentFactoryConfig {
 
   /**
    * Override for the virtual staging API base URL.
-   * E.g. https://virtual-staging.adis.ws
+   * E.g. https://virtual-staging.amplience.net
    */
   baseUrl?: string;
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the new behaviour?

### Functionality
- References to c1.adis.ws => cdn.c1.amplience.net
- References to virtual-staging.adis.ws => virtual-staging.amplience.net

### Tests and fixtures (for consistency)
- References to i1.adis.ws => cdn.media.amplience.net
- References to invalid.adis.ws => invalid.cdn.media.amplience.net
- References to default.adis.ws => default.cdn.media.amplience.net
- References to secure.adis.ws => secure.cdn.media.amplience.net
- References to staging.adis.ws => staging.bigcontent.io

## Does this introduce a breaking change?

- [ ] Yes
- [x] No